### PR TITLE
FIXES DeprecationWarnings for django-1.3.

### DIFF
--- a/djangoratings/fields.py
+++ b/djangoratings/fields.py
@@ -357,11 +357,12 @@ class RatingField(IntegerField):
 
         setattr(cls, name, field)
 
-    def get_db_prep_save(self, value):
+    def get_db_prep_save(self, value, connection=None):
         # XXX: what happens here?
         pass
 
-    def get_db_prep_lookup(self, lookup_type, value):
+    def get_db_prep_lookup(self, lookup_type, value, connection=None, 
+                           prepared=None):
         # TODO: hack in support for __score and __votes
         # TODO: order_by on this field should use the weighted algorithm
         raise NotImplementedError(self.get_db_prep_lookup)


### PR DESCRIPTION
- djangoratings/fields.py:319: DeprecationWarning: A Field class whose
  get_db_prep_save method hasn't been updated to take a `connection` argument.
  -djangoratings/fields.py:319: DeprecationWarning: A Field class whose
  get_db_prep_lookup method hasn't been updated to take `connection` and
  `prepared` arguments.
