### PR TITLE
Fixes crash for updating votes (in Django 1.0)?

### DIFF
--- a/djangoratings/fields.py
+++ b/djangoratings/fields.py
@@ -173,7 +173,7 @@ class RatingManager(object):
             cookie = cookies.get(cookie_name) # try to get existent cookie value
             if not cookie:
                 kwargs['cookie__isnull'] = True
-            kwargs['cookie'] = cookie
+            kwargs['cookie'] = unicode(cookie)
 
         try:
             rating, created = Vote.objects.get(**kwargs), False


### PR DESCRIPTION
When updating a vote that was already made, Django 1.0 crashes with a ValueError, caused by trying to use an uncast StringMorsel in a query. This pull casts cookies to unicode before passing them to a query.
